### PR TITLE
feat: blocks schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-	"format": "prettier src --write"
+    "format": "prettier src --write"
   },
   "devDependencies": {
     "@sveltejs/adapter-auto": "^2.0.0",
@@ -30,6 +30,7 @@
     "clsx": "^2.0.0",
     "lucide-svelte": "^0.285.0",
     "tailwind-merge": "^1.14.0",
-    "tailwind-variants": "^0.1.14"
+    "tailwind-variants": "^0.1.14",
+    "zod": "^3.22.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ dependencies:
   tailwind-variants:
     specifier: ^0.1.14
     version: 0.1.14(tailwindcss@3.3.3)
+  zod:
+    specifier: ^3.22.4
+    version: 3.22.4
 
 devDependencies:
   '@sveltejs/adapter-auto':
@@ -1446,3 +1449,7 @@ packages:
   /yaml@2.3.2:
     resolution: {integrity: sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg==}
     engines: {node: '>= 14'}
+
+  /zod@3.22.4:
+    resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
+    dev: false

--- a/src/lib/schema/blocks/checkbox.ts
+++ b/src/lib/schema/blocks/checkbox.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+const blockType = z.literal("checkbox");
+const optionSchema = z.object({
+	value: z.string(),
+	label: z.string(),
+});
+
+export const checkboxBlockSchema = z.object({
+	type: blockType,
+	required: z.boolean(),
+	title: z.string(),
+	options: z.array(optionSchema),
+});
+export type CheckboxBlock = z.infer<typeof checkboxBlockSchema>;
+
+export const checkboxBlockValueSchema = z.object({
+	type: blockType,
+	value: z.array(z.string()),
+});
+export type CheckboxBlockValue = z.infer<typeof checkboxBlockValueSchema>;

--- a/src/lib/schema/blocks/date.ts
+++ b/src/lib/schema/blocks/date.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+const blockType = z.literal("date");
+
+export const dateBlockSchema = z.object({
+	type: blockType,
+	required: z.boolean(),
+	title: z.string(),
+});
+export type DateBlock = z.infer<typeof dateBlockSchema>;
+
+export const dateBlockValueSchema = z.object({
+	type: blockType,
+	value: z.date(),
+});
+export type DateBlockValue = z.infer<typeof dateBlockValueSchema>;

--- a/src/lib/schema/blocks/linear-scale.ts
+++ b/src/lib/schema/blocks/linear-scale.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+const blockType = z.literal("linear-scale");
+
+export const linearScaleBlockSchema = z.object({
+	type: blockType,
+	required: z.boolean(),
+	title: z.string(),
+	min: z.object({
+		label: z.string().optional(),
+		value: z.number(),
+	}),
+	max: z.object({
+		label: z.string().optional(),
+		value: z.number(),
+	}),
+});
+export type LinearScaleBlock = z.infer<typeof linearScaleBlockSchema>;
+
+export const linearScaleBlockValueSchema = z.object({
+	type: blockType,
+	value: z.number(),
+});
+export type LinearScaleBlockValue = z.infer<typeof linearScaleBlockValueSchema>;

--- a/src/lib/schema/blocks/paragraph.ts
+++ b/src/lib/schema/blocks/paragraph.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+const blockType = z.literal("paragraph");
+
+export const paragraphBlockSchema = z.object({
+	type: blockType,
+	required: z.boolean(),
+	title: z.string(),
+	placeholder: z.string(),
+});
+export type ParagraphBlock = z.infer<typeof paragraphBlockSchema>;
+
+export const paragraphBlockValueSchema = z.object({
+	type: blockType,
+	value: z.string(),
+});
+export type ParagraphBlockValue = z.infer<typeof paragraphBlockValueSchema>;

--- a/src/lib/schema/blocks/radio.ts
+++ b/src/lib/schema/blocks/radio.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+const blockType = z.literal("radio");
+const optionSchema = z.object({
+	value: z.string(),
+	label: z.string(),
+});
+
+export const radioBlockSchema = z.object({
+	type: blockType,
+	required: z.boolean(),
+	title: z.string(),
+	options: z.array(optionSchema),
+});
+export type RadioBlock = z.infer<typeof radioBlockSchema>;
+
+export const radioBlockValueSchema = z.object({
+	type: blockType,
+	value: z.string(),
+});
+export type RadioBlockValue = z.infer<typeof radioBlockValueSchema>;

--- a/src/lib/schema/blocks/select.ts
+++ b/src/lib/schema/blocks/select.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+const blockType = z.literal("select");
+const optionSchema = z.object({
+	value: z.string(),
+	label: z.string(),
+});
+
+export const selectBlockSchema = z.object({
+	type: blockType,
+	required: z.boolean(),
+	title: z.string(),
+	options: z.array(optionSchema),
+});
+export type SelectBlock = z.infer<typeof selectBlockSchema>;
+
+export const selectBlockValueSchema = z.object({
+	type: blockType,
+	value: z.string(),
+});
+export type SelectBlockValue = z.infer<typeof selectBlockValueSchema>;

--- a/src/lib/schema/blocks/text.ts
+++ b/src/lib/schema/blocks/text.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+const blockType = z.literal("text");
+
+export const textBlockSchema = z.object({
+	type: blockType,
+	required: z.boolean(),
+	title: z.string(),
+	placeholder: z.string(),
+});
+export type TextBlock = z.infer<typeof textBlockSchema>;
+
+export const textBlockValueSchema = z.object({
+	type: blockType,
+	value: z.string(),
+});
+export type TextBlockValue = z.infer<typeof textBlockValueSchema>;

--- a/src/lib/schema/blocks/time.ts
+++ b/src/lib/schema/blocks/time.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+const blockType = z.literal("time");
+
+export const timeBlockSchema = z.object({
+	type: blockType,
+	required: z.boolean(),
+	title: z.string(),
+});
+export type TimeBlock = z.infer<typeof timeBlockSchema>;
+
+export const timeBlockValueSchema = z.object({
+	type: blockType,
+	value: z.date(),
+});
+export type TimeBlockValue = z.infer<typeof timeBlockValueSchema>;


### PR DESCRIPTION
this PR adds schema for every blocks we might need using zod
since MongoDB is a schema-less database, we need to have the schema in our app to maintain consistency

things might seem repetitive and not DRY but actually it's not repetitive, since we're using zod's `literal` which is one way of achieving nominal typing in Typescript, they should be different from one another